### PR TITLE
fix: correct selected date highlight on calendar

### DIFF
--- a/src/app/dashboard/DatePicker.tsx
+++ b/src/app/dashboard/DatePicker.tsx
@@ -5,11 +5,15 @@ import { Calendar } from "@/components/ui/calendar";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface DatePickerProps {
-  selectedDate: Date;
+  selectedDate: string; // ISO date string like "2026-04-15"
 }
 
 export function DatePicker({ selectedDate }: DatePickerProps) {
   const router = useRouter();
+
+  // Construct date in the browser's local timezone to avoid UTC offset issues
+  const [year, month, day] = selectedDate.split("-").map(Number);
+  const localDate = new Date(year, month - 1, day);
 
   function handleSelect(date: Date | undefined) {
     if (!date) return;
@@ -30,7 +34,7 @@ export function DatePicker({ selectedDate }: DatePickerProps) {
       <CardContent className="p-0 pb-4 flex justify-center">
         <Calendar
           mode="single"
-          selected={selectedDate}
+          selected={localDate}
           onSelect={handleSelect}
         />
       </CardContent>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,7 +14,9 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
   const { userId } = await auth();
   const { date: dateParam } = await searchParams;
 
-  const selectedDate = dateParam ? new Date(dateParam + "T00:00:00") : new Date();
+  const todayIso = new Date().toLocaleDateString("en-CA"); // "YYYY-MM-DD" in local time
+  const selectedDateIso = dateParam ?? todayIso;
+  const selectedDate = new Date(selectedDateIso + "T00:00:00");
   selectedDate.setHours(0, 0, 0, 0);
 
   const workoutList = userId
@@ -27,7 +29,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
         <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
 
         <div className="grid grid-cols-1 md:grid-cols-[auto_1fr] gap-6 items-start">
-          <DatePicker selectedDate={selectedDate} />
+          <DatePicker selectedDate={selectedDateIso} />
 
           <div className="space-y-4">
             <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes #11

When clicking a date on the dashboard, the wrong date was being highlighted due to a UTC timezone offset issue. The `DatePicker` client component now receives an ISO date string and constructs the Date object in the browser's local timezone.

Generated with [Claude Code](https://claude.ai/code)