### PR TITLE
feat: add workout detail page to fix 404 on workout selection

### DIFF
--- a/src/app/dashboard/workout/[id]/page.tsx
+++ b/src/app/dashboard/workout/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getWorkoutById } from "@/data/workouts";
+
+interface WorkoutPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function WorkoutPage({ params }: WorkoutPageProps) {
+  const { id } = await params;
+  const { userId } = await auth();
+
+  if (!userId) {
+    notFound();
+  }
+
+  const workout = await getWorkoutById(userId, id);
+
+  if (!workout) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <div className="flex items-center gap-4">
+          <Button asChild variant="outline" size="sm">
+            <Link href="/dashboard">← Back</Link>
+          </Button>
+          <h1 className="text-3xl font-bold tracking-tight">{workout.name}</h1>
+        </div>
+
+        {workout.exercises.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground">
+              No exercises logged for this workout.
+            </CardContent>
+          </Card>
+        ) : (
+          workout.exercises.map((exercise) => (
+            <Card key={exercise.id}>
+              <CardHeader>
+                <CardTitle className="text-base">{exercise.name}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {exercise.sets.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No sets logged.</p>
+                ) : (
+                  <div className="divide-y">
+                    {exercise.sets.map((set) => (
+                      <div key={set.id} className="py-2 flex justify-between text-sm">
+                        <span>Set {set.setNumber}</span>
+                        <span className="text-muted-foreground">
+                          {set.reps != null ? `${set.reps} reps` : "—"}
+                          {set.weight ? ` @ ${set.weight}kg` : ""}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/data/workouts.ts
+++ b/src/data/workouts.ts
@@ -10,6 +10,70 @@ export async function createWorkout(userId: string, name: string) {
   return workout;
 }
 
+export async function getWorkoutById(userId: string, workoutId: string) {
+  const rows = await db
+    .select({
+      workoutId: workouts.id,
+      workoutName: workouts.name,
+      workoutStartedAt: workouts.startedAt,
+      workoutExerciseId: workoutExercises.id,
+      exerciseName: exercises.name,
+      exerciseOrder: workoutExercises.order,
+      setId: sets.id,
+      setNumber: sets.setNumber,
+      reps: sets.reps,
+      weight: sets.weight,
+    })
+    .from(workouts)
+    .leftJoin(workoutExercises, eq(workoutExercises.workoutId, workouts.id))
+    .leftJoin(exercises, eq(exercises.id, workoutExercises.exerciseId))
+    .leftJoin(sets, eq(sets.workoutExerciseId, workoutExercises.id))
+    .where(and(eq(workouts.id, workoutId), eq(workouts.userId, userId)))
+    .orderBy(workoutExercises.order, sets.setNumber);
+
+  if (rows.length === 0) return null;
+
+  const exerciseMap = new Map<
+    string,
+    {
+      id: string;
+      name: string;
+      order: number;
+      sets: { id: string; setNumber: number; reps: number | null; weight: string | null }[];
+    }
+  >();
+
+  for (const row of rows) {
+    if (row.workoutExerciseId && row.exerciseName) {
+      if (!exerciseMap.has(row.workoutExerciseId)) {
+        exerciseMap.set(row.workoutExerciseId, {
+          id: row.workoutExerciseId,
+          name: row.exerciseName,
+          order: row.exerciseOrder ?? 0,
+          sets: [],
+        });
+      }
+      const exercise = exerciseMap.get(row.workoutExerciseId)!;
+      if (row.setId) {
+        exercise.sets.push({
+          id: row.setId,
+          setNumber: row.setNumber!,
+          reps: row.reps,
+          weight: row.weight,
+        });
+      }
+    }
+  }
+
+  const first = rows[0];
+  return {
+    id: first.workoutId,
+    name: first.workoutName,
+    startedAt: first.workoutStartedAt,
+    exercises: Array.from(exerciseMap.values()),
+  };
+}
+
 export async function getWorkoutsForUserOnDate(userId: string, date: Date) {
   const startOfDay = new Date(date);
   startOfDay.setHours(0, 0, 0, 0);


### PR DESCRIPTION
Fixes #12

Adds the missing dynamic route `/dashboard/workout/[id]` so clicking a workout on the dashboard no longer results in a 404.

- Added `getWorkoutById` data helper in `src/data/workouts.ts`
- Created `src/app/dashboard/workout/[id]/page.tsx` with workout detail view

Generated with [Claude Code](https://claude.ai/code)