### PR TITLE
feat: protect /dashboard routes with Clerk auth

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,12 @@
-import { clerkMiddleware } from '@clerk/nextjs/server'
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-export default clerkMiddleware()
+const isProtectedRoute = createRouteMatcher(['/dashboard(.*)'])
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) {
+    await auth.protect()
+  }
+})
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Unauthenticated users visiting /dashboard or any sub-route are now redirected to sign-in via Clerk's auth.protect().

Closes #15

Generated with [Claude Code](https://claude.ai/code)