### PR TITLE
feat: add Log New Workout button on dashboard empty state

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { format } from "date-fns";
 import Link from "next/link";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { DatePicker } from "./DatePicker";
 import { getWorkoutsForUserOnDate } from "@/data/workouts";
 
@@ -44,8 +45,13 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
 
             {workoutList.length === 0 ? (
               <Card>
-                <CardContent className="py-12 text-center text-muted-foreground">
-                  No workouts logged for this date.
+                <CardContent className="py-12 flex flex-col items-center gap-4 text-center text-muted-foreground">
+                  <p>No workouts logged for this date.</p>
+                  <Button asChild>
+                    <Link href={`/dashboard/workout/new?date=${selectedDateIso}`}>
+                      Log New Workout
+                    </Link>
+                  </Button>
                 </CardContent>
               </Card>
             ) : (

--- a/src/app/dashboard/workout/new/NewWorkoutForm.tsx
+++ b/src/app/dashboard/workout/new/NewWorkoutForm.tsx
@@ -15,7 +15,11 @@ const schema = z.object({
 
 type FormValues = z.infer<typeof schema>;
 
-export function NewWorkoutForm() {
+interface NewWorkoutFormProps {
+  returnDate?: string;
+}
+
+export function NewWorkoutForm({ returnDate }: NewWorkoutFormProps) {
   const router = useRouter();
   const {
     register,
@@ -27,7 +31,7 @@ export function NewWorkoutForm() {
 
   async function onSubmit(values: FormValues) {
     await createWorkoutAction(values);
-    router.push("/dashboard");
+    router.push(returnDate ? `/dashboard?date=${returnDate}` : "/dashboard");
   }
 
   return (

--- a/src/app/dashboard/workout/new/page.tsx
+++ b/src/app/dashboard/workout/new/page.tsx
@@ -1,7 +1,13 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { NewWorkoutForm } from "./NewWorkoutForm";
 
-export default function NewWorkoutPage() {
+interface NewWorkoutPageProps {
+  searchParams: Promise<{ date?: string }>;
+}
+
+export default async function NewWorkoutPage({ searchParams }: NewWorkoutPageProps) {
+  const { date } = await searchParams;
+
   return (
     <div className="min-h-screen bg-background p-6">
       <div className="max-w-lg mx-auto">
@@ -11,7 +17,7 @@ export default function NewWorkoutPage() {
             <CardTitle>Create a Workout</CardTitle>
           </CardHeader>
           <CardContent>
-            <NewWorkoutForm />
+            <NewWorkoutForm returnDate={date} />
           </CardContent>
         </Card>
       </div>


### PR DESCRIPTION
Adds a "Log New Workout" button to the empty state on the dashboard page when no workouts are logged for the selected date. After creation, redirects back to the same date on the dashboard.

Closes #17

Generated with [Claude Code](https://claude.ai/code)